### PR TITLE
Run with the latest version of clojure, alpha15

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
                  [incanter/incanter-core "1.5.6"]
                  [incanter/incanter-charts "1.5.6"]
                  [io.aviso/pretty "0.1.26"]
-                 [org.clojure/clojure "1.9.0-alpha14"]
+                 [org.clojure/clojure "1.9.0-alpha15"]
                  [org.clojure/tools.cli "0.3.5"]
                  [prismatic/schema "1.1.3"]]
   :plugins [[io.aviso/pretty "0.1.26"]]


### PR DESCRIPTION
Alpha 15 has been released. I didn't find any further mentions of the number 14 in the source code.